### PR TITLE
Initial content based on pycon github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-TODO: Code of Conduct goes here
+wtf-code-of-conduct
+=====================
+
+Thank you to the WTF18 attendees and Matt Brandt of Mozilla for encouraging the creation of a Code of Conduct for the Winter Tech Forum.  This initial Code of Conduct is based on a fork of the 2015 PyCon version.
+
+We hope, as a conference community, that we can iterate and improve continually.
+
+The version posted on this GitHub repository is a work in progress and should not be considered final until approved by the conference organizers and distributed to attendees for acceptance of these terms as a condition of registration, which will clearly state the posted revision tag.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,55 @@
+The Winter Tech Forum in Crested Butte, Colorado, US is a community conference intended for networking and collaboration in the developer community.
+
+We value the participation of each member of the conference community and want all participants to have an enjoyable and fulfilling experience. Accordingly, all participants are expected to show respect and courtesy to other participants throughout the conference and at all conference events, whether part of the official WTF conference activities or not.
+
+To make clear what is expected, all participants at any WTF activity are required to conform to the following Code of Conduct. Organizers and participants will enforce this code throughout the event.
+
+The Short Version
+-----------------
+
+The Winter Tech Forum is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of conference participants in any form.
+
+All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate for any conference venue, including talks.
+
+Be kind to others. Do not insult or put down other participants. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for WTF.
+
+Participants violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.
+
+Thank you for helping make this a welcoming, friendly event for all.
+
+The Longer Version
+------------------
+
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for WTF.
+
+If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+
+Contact Information
+-------------------
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact the Conference Organizer or an "Alumni" participant with whom you feel comfortable. Organizers and Alumni participants will be introduced at the beginning of the conference.
+
+If the matter is especially urgent, please call/contact any of these individuals:
+
+- (TBD, pending whether conference organizer has an appropriate number to publish in this document)
+
+The conference organizer and alumni participants will be happy to help any other participant contact local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+
+Procedure for Handling Harassment
+------------------------------------------
+- [Participant Procedure for incident handling](procedure_participant.md)
+- [Organizer/Alumni Procedure for incident handling](procedure_org_alum.md)
+
+License
+-------
+
+This Code of Conduct was forked from the PyCon 2015 policy (https://github.com/python/pycon-code-of-conduct). Attribution: <a rel="license" href="http://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/3.0/88x31.png" /></a> <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Conference Code of Conduct</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://us.pycon.org/2013/about/code-of-conduct/" property="cc:attributionName" rel="cc:attributionURL">https://us.pycon.org/2013/about/code-of-conduct/</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution 3.0 Unported License</a>.
+
+The PyCon version was was forked from the example policy from the [Geek Feminism wiki, created by the Ada Initiative and other volunteers.](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) which is under a Creative Commons Zero license.
+
+Those licenses apply to any subsequent fork/reuse of this document.
+

--- a/procedure_org_alum.md
+++ b/procedure_org_alum.md
@@ -1,0 +1,65 @@
+This procedure has been adopted from the Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)”.
+
+-------------------------------------------------------------------------------------------------
+Be sure to have a good understanding of our Code of Conduct policy, which can be found here: [code_of_conduct.md](code_of_conduct.md)
+
+Also have a good understanding of what is expected from a participant that wants to report a harassment incident. These guidelines can be found here: [procedure_participant.md](procedure_participant.md)
+
+Try to get as much of the incident in written form by the reporter. If you cannot, transcribe it yourself as it was told to you. The important information to gather include the following:
+
+ - Identifying information (name/description) of the participant doing the harassing
+ - The behavior that was in violation
+ - The approximate time of the behavior (if different than the time the report was made)
+ - The circumstances surrounding the incident
+ - Other people involved in the incident
+
+Prepare an initial response to the incident. This initial response is very important and will set the tone for WTF. Depending on the severity/details of the incident, please follow these guidelines:
+
+ - If there is any general threat to participants or the safety of anyone including conference organizers is in doubt, summon security or police
+ - Offer the victim a private place to sit
+ - Ask "is there a friend or trusted person who you would like to be with you?" (if so, arrange for someone to fetch this person)
+ - Ask them "how can I help?"
+ - Provide them with your list of emergency contacts if they need help later
+ - If everyone is presently physically safe, involve law enforcement or security only at a victim's request
+
+There are also some guidelines as to what not to do as an initial response:
+
+ - Do not overtly invite them to withdraw the complaint or mention that withdrawal is OK. This suggests that you want them to do so, and is therefore coercive. "If you're OK with it [pursuing the complaint]" suggests that you are by default pursuing it and is not coercive.
+ - Do not ask for their advice on how to deal with the complaint. This is an organizer responsibility.
+ - Do not offer them input into penalties. This is the organizers' responsibility.
+
+Once something is reported to an organizer or alumni participant, immediately convene an "Adjudicating Committee" composed of conference organizers and appropriate "senior" conference alumni. The main objectives of this meeting is to find out the following:
+
+ - What happened?
+ - Are we doing anything about it?
+ - Who is doing those things?
+ - When are they doing them?
+
+After the adjudicating committee meeting and discussion, have one of the members (preferably a conference organizer) communicate with the alleged harasser. Make sure to inform them of what has been reported about them.
+
+Allow the alleged harasser to give their side of the story to the staff. After this point, if the report stands, let the alleged harasser know what actions will be taken against them.
+
+Some things for the committee to consider when dealing with Code of Conduct offenders:
+
+- Warning the harasser to cease their behavior and that any further reports will result in sanctions
+- Requiring that the harasser avoid any interaction with, and physical proximity to, their victim for the remainder of the event
+- Ending a talk that violates the policy early
+- Not publishing the video or slides of a talk that violated the policy
+- Not allowing a speaker who violated the policy to give (further) talks at the event now or in the future
+- Immediately ending any event volunteer responsibilities and privileges the harasser holds
+- Requiring that the harasser not volunteer for future events your organization runs (either indefinitely or for a certain time period)
+- Requiring that the harasser refund any travel grants and similar they received (this would need to be a condition of the grant at the time of being awarded)
+- Requiring that the harasser immediately leave the event and not return
+- Banning the harasser from future events (either indefinitely or for a certain time period)
+- Removing a harasser from membership of relevant organizations
+- Publishing an account of the harassment and calling for the resignation of the harasser from their responsibilities (usually pursued by people without formal authority: may be called for if the harasser is the event leader, or refuses to stand aside from the conflict of interest, or similar, typically event staff have sufficient governing rights over their space that this isn't as useful)
+
+Give accused participants a place to appeal to if there is one, but in the meantime the report stands. Keep in mind that it is not a good idea to encourage an apology from the harasser.
+
+It is very important how we deal with the incident publicly. Our policy is to make sure that everyone aware of the initial incident is also made aware that it is not according to policy and that official action has been taken - while still respecting the privacy of individual attendees.  When speaking to individuals (those who are aware of the incident, but were not involved with the incident) about the incident it is a good idea to keep the details out.
+
+Depending on the incident, the conference organizer, or designate, may decide to make one or more public announcements. If necessary, this will be done with a short announcement either during the plenary and/or through other channels. No one other than a conference organizer or someone delegated authority from the conference organizer should make any announcements. No personal information about either party will be disclosed as part of this process.
+
+If some participants were angered by the incident, it is best to apologize to them that the incident occurred to begin with.  If there are residual hard feelings, suggest to them to write an email to the conference organizer or to the event coordinator. It will be dealt with accordingly.
+
+If at all possible, all reports should be made directly to [Bruce Eckel](mailto:mindviewinc@gmail.com) (Organizer).

--- a/procedure_participant.md
+++ b/procedure_participant.md
@@ -1,0 +1,28 @@
+This procedure has been adopted from the Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)”.
+
+1\. Keep in mind that all conference organizers and alumni participants will be introduced at the start of the conference.  Organizers and alumni participants will be given instructions on how to handle an incident.  
+All of our organizers and participants are informed of the [code of conduct policy](code_of_conduct.md) and guide for handling harassment at the conference. *There will be a mandatory acknowledgement of this policy when registering for the conference.*
+
+2\. Report the harassment incident (preferably in writing) to a conference organizer or alumni participants that you feel comfortable around. All reports are confidential. Please do not disclose public information about the incident until the organizers have had sufficient time in which to address the situation. This is as much for your safety and protection as it is the other participants.
+
+When reporting the event to organizers or alumni, try to gather as much information as available but do not interview people about the incident. Organizers and alumni will assist you in writing the report/collecting information.
+
+The important information consists of:
+
+- Identifying information (name) of the participant doing the harassing
+- The behavior that was in violation
+- The approximate time of the behavior (if different than the time the report was made)
+- The circumstances surrounding the incident
+- Other people involved in or witness to the incident
+
+The organizers are well informed on how to deal with the incident and how to further proceed with the situation.
+
+3\. If everyone is presently physically safe, involve law enforcement or security only at a victim's request.  If you do feel your safety in jeopardy please do not hesitate to contact local law enforcement by dialing 911. If you do not have a cell phone, you can use any available phone or simply ask another participant.
+
+**Note**: Incidents that violate the Code of Conduct are extremely damaging to the community, and they
+will not be tolerated. The silver lining is that, in many cases, these incidents present a chance for
+the offenders, and the community at large, to grow, learn, and become better. WTF organizers and alumni request
+that they be your first resource when reporting a WTF-related incident, so that they may enforce
+the Code of Conduct and take quick action toward a resolution.
+
+If at all possible, all reports should be made directly to [Bruce Eckel](mailto:mindviewinc@gmail.com) (Organizer).


### PR DESCRIPTION
#1 

Some initial content based on pycon (https://github.com/python/pycon-code-of-conduct)

* Changed staff to conference organizer
* Change attendee to participant
* Try to account for how WTF is mostly self-organizing
* Add idea of "Adjudicating Committee" (like how a sailing Protest Committee is formed)

Please shred this, add commits, or submit a totally different PR for community discussion.